### PR TITLE
chore: rm webrtc replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,6 @@ module cdr.dev/coder-cli
 
 go 1.14
 
-// TODO: remove the replace once this PR gets merged:
-// https://github.com/pion/webrtc/pull/1946
-replace github.com/pion/webrtc/v3 => github.com/deansheather/webrtc/v3 v3.1.0-beta.6.0.20210907233552-57c66b872d12
-
 require (
 	cdr.dev/slog v1.4.1
 	cdr.dev/wsep v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,6 @@ github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deansheather/webrtc/v3 v3.1.0-beta.6.0.20210907233552-57c66b872d12 h1:NW5uk8N+M5hp5TOTcGi9a5/ZFyeG8sTVQIAKZFAWhJM=
-github.com/deansheather/webrtc/v3 v3.1.0-beta.6.0.20210907233552-57c66b872d12/go.mod h1:KQH/wVKKJzBTQ6sX1bDTxsvTpQ6gEjVZSJlzYaB58aM=
 github.com/dlclark/regexp2 v1.1.6/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
@@ -352,6 +350,8 @@ github.com/pion/turn/v2 v2.0.5 h1:iwMHqDfPEDEOFzwWKT56eFmh6DYC6o/+xnLAEzgISbA=
 github.com/pion/turn/v2 v2.0.5/go.mod h1:APg43CFyt/14Uy7heYUOGWdkem/Wu4PhCO/bjyrTqMw=
 github.com/pion/udp v0.1.1 h1:8UAPvyqmsxK8oOjloDk4wUt63TzFe9WEJkg5lChlj7o=
 github.com/pion/udp v0.1.1/go.mod h1:6AFo+CMdKQm7UiA0eUPA8/eVCTx8jBIITLZHc9DWX5M=
+github.com/pion/webrtc/v3 v3.1.0-beta.7 h1:m8RmktWfCaNwTqGnE99me9qz6cI24rL4bK0BHtBH8Fs=
+github.com/pion/webrtc/v3 v3.1.0-beta.7/go.mod h1:KQH/wVKKJzBTQ6sX1bDTxsvTpQ6gEjVZSJlzYaB58aM=
 github.com/pkg/browser v0.0.0-20210904010418-6d279e18f982 h1:TdFv+3Gr3GaghJ/o80aulO4ian7GHGWMdLBXoLZH1Is=
 github.com/pkg/browser v0.0.0-20210904010418-6d279e18f982/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
removes the webrtc `replace` directive since [this PR](https://github.com/pion/webrtc/pull/1946) was merged.